### PR TITLE
Autotech knowledge req tooltip

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7276,16 +7276,19 @@ $(".research_economy").html("Economy " + intToString(bonus["economy"]));
 $(".research_economy").attr('tooltip', "Economy its a big force, prosperity and wealth awaits for those ");
 $(".research_economy").attr('tooltip2', "who look for it.");
 $(".research_economy").attr('tooltip4', "Also increases global production");
+if(bonus["economy"]>100000) {$(".research_economy").attr('tooltip6', 'An additional investment of ' + parseFloat(Math.pow(1.1,Math.round(Math.ceil(Math.log(bonus["economy"]/100000)/Math.log(1.1),0)))*100000-bonus["economy"]).toFixed(2) + ' knowledge will unlock the next AutoTech.');}
 
 $(".research_science").html("Science " + intToString(bonus["science"]));
 $(".research_science").attr('tooltip', "Science leads humanity forward, it can be slow, ");
 $(".research_science").attr('tooltip2', "but it never stops evolving. ");
 $(".research_science").attr('tooltip4', "Also increases craft efficiency");
+if(bonus["science"]>100000) {$(".research_science").attr('tooltip6', 'An additional investment of ' + parseFloat(Math.pow(1.1,Math.round(Math.ceil(Math.log(bonus["science"]/100000)/Math.log(1.1),0)))*100000-bonus["science"]).toFixed(2) + ' knowledge will unlock the next AutoTech.');}
 
 $(".research_military").html("Military " + intToString(bonus["military"]));
 $(".research_military").attr('tooltip', "There are times, when only the most powerfull get what he wants,");
 $(".research_military").attr('tooltip2', "is that you?");
 $(".research_military").attr('tooltip4', "Also increases troops attack and hp");
+if(bonus["military"]>100000) {$(".research_military").attr('tooltip6', 'An additional investment of ' + parseFloat(Math.pow(1.1,Math.round(Math.ceil(Math.log(bonus["military"]/100000)/Math.log(1.1),0)))*100000-bonus["military"]).toFixed(2) + ' knowledge will unlock the next AutoTech.');}
 
 
 //crafting


### PR DESCRIPTION
Adds a line to each of the specialization tool tips that indicates how much additional investment is required to unlock the next autotech. Only appears when the autotechs are available (over 100,000 knowledge invested for a given specialization)
