### PR TITLE
fixes to the combat logs

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -913,16 +913,16 @@ function fight(){
 		}
 		if(i==0 && burst>0){
 			combatlog+="Your troops smash into the enemy lines and deal "+intToString(dmg1)+" damage!<br>"
-		} else if(dmg1>power*1.1){
+		} else if(dmg1>(power+disobey+reload)*1.15){
 			combatlog+="Your troops find a weak spot and deal "+intToString(dmg1)+" damage!<br>"
-		} else if(dmg1<power*.9){
+		} else if(dmg1<(power+disobey+reload)*.85){
 			combatlog+="Your troops hesitate, and only deal "+intToString(dmg1)+" damage.<br>"
 		} else {
 			combatlog+="Your troops deal "+intToString(dmg1)+" damage.<br>"
 		}
-		if(dmg2>power2*1.1){
+		if(dmg2>power2*1.15){
 			combatlog+="The enemy finds a weak spot and deals "+intToString(dmg2)+" damage!<br>"
-		} else if(dmg2<power2*.9){
+		} else if(dmg2<power2*.85){
 			combatlog+="The enemy hesitates, and only deals "+intToString(dmg2)+" damage.<br>"
 		} else {
 			combatlog+="The enemy deals "+intToString(dmg2)+" damage.<br>"

--- a/js/main.js
+++ b/js/main.js
@@ -917,7 +917,7 @@ function fight(){
 			combatlog+="Your troops find a weak spot and deal "+intToString(dmg1)+" damage!<br>"
 		} else if(dmg1<(power+disobey+reload)*.85){
 			combatlog+="Your troops hesitate, and only deal "+intToString(dmg1)+" damage.<br>"
-		} else {
+		} else if(dmg1>0){
 			combatlog+="Your troops deal "+intToString(dmg1)+" damage.<br>"
 		}
 		if(dmg2>power2*1.15){


### PR DESCRIPTION
-makes the critical hit and critical fail messages occur at roughly 10% probabilities
-fixes calculation to see if a hit was critical or not
-removes 'damage dealt' message if the troops deal no damage (ie when an army made up of only reloading units has a reloading turn)
