### PR TITLE
Adding "Buy Max" buttons next to marketplace commodities

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -154,7 +154,7 @@ font-size:10px;
     padding: 5px 15px;
     position: absolute;
     z-index: 98;
-    margin-left:10px;
+    margin-left:20px;
     width: auto;
     height:auto;
      white-space: pre;

--- a/css/style.css
+++ b/css/style.css
@@ -120,13 +120,24 @@ font-size:10px;
   margin-top:15px;
 }
 
-.trade, .trademax{
+.trade{
     border:1px solid black;
     cursor:pointer;
     padding:5px;
     width:200px!important;
     margin-top:10px;
     display: inline-block;
+}
+
+.trademax{
+    border:1px solid black;
+    cursor:pointer;
+    padding:5px;
+    width:50px!important;
+    margin-top:10px;
+    margin-left:20px;
+    display: inline-block;
+    content: attr(tooltip) "\A" attr(tooltip2) "\A" attr(tooltip3) "\A" attr(tooltip4) "\A" attr(tooltip5) "\A" attr(tooltip6) "\A" attr(tooltip7);
 }
 
 .bonus{

--- a/css/style.css
+++ b/css/style.css
@@ -129,15 +129,24 @@ font-size:10px;
     display: inline-block;
 }
 
-.trademax{
-    border:1px solid black;
-    cursor:pointer;
-    padding:5px;
-    width:50px!important;
-    margin-top:10px;
+  .trademax[style*="display: none;"]{
+    padding:0px;
+    margin-top:0px;
+    width:0px;
+  }
+  .trademax:hover:after{
+    background: #333;
+    background: rgba(0,0,0,.8);
+    border-radius: 5px;
+    color: #fff;
+    content: attr(tooltip) "\A" attr(tooltip2) "\A" attr(tooltip3) "\A" attr(tooltip4) "\A" attr(tooltip5) "\A" attr(tooltip6) "\A" attr(tooltip7);;
+    padding: 5px 15px;
+    position: absolute;
+    z-index: 98;
     margin-left:20px;
-    display: inline-block;
-    content: attr(tooltip) "\A" attr(tooltip2) "\A" attr(tooltip3) "\A" attr(tooltip4) "\A" attr(tooltip5) "\A" attr(tooltip6) "\A" attr(tooltip7);
+    width: auto;
+    height:auto;
+     white-space: pre;
 }
 
 .bonus{

--- a/css/style.css
+++ b/css/style.css
@@ -128,7 +128,18 @@ font-size:10px;
     margin-top:10px;
     display: inline-block;
 }
-
+  .trademax{
+  	border:1px solid black;
+  	cursor:pointer;
+  	padding:5px;
+  	width:220px;
+    margin-top:10px;
+    display: inline-block;
+    font-size:15px;
+-webkit-user-select: none; /* Chrome/Safari */        
+-moz-user-select: none; /* Firefox */
+-ms-user-select: none;
+  }
   .trademax[style*="display: none;"]{
     padding:0px;
     margin-top:0px;
@@ -143,7 +154,7 @@ font-size:10px;
     padding: 5px 15px;
     position: absolute;
     z-index: 98;
-    margin-left:20px;
+    margin-left:10px;
     width: auto;
     height:auto;
      white-space: pre;

--- a/css/style.css
+++ b/css/style.css
@@ -128,37 +128,6 @@ font-size:10px;
     margin-top:10px;
     display: inline-block;
 }
-  .trademax{
-  	border:1px solid black;
-  	cursor:pointer;
-  	padding:5px;
-  	width:220px;
-    margin-top:10px;
-    display: inline-block;
-    font-size:15px;
--webkit-user-select: none; /* Chrome/Safari */        
--moz-user-select: none; /* Firefox */
--ms-user-select: none;
-  }
-  .trademax[style*="display: none;"]{
-    padding:0px;
-    margin-top:0px;
-    width:0px;
-  }
-  .trademax:hover:after{
-    background: #333;
-    background: rgba(0,0,0,.8);
-    border-radius: 5px;
-    color: #fff;
-    content: attr(tooltip) "\A" attr(tooltip2) "\A" attr(tooltip3) "\A" attr(tooltip4) "\A" attr(tooltip5) "\A" attr(tooltip6) "\A" attr(tooltip7);;
-    padding: 5px 15px;
-    position: absolute;
-    z-index: 98;
-    margin-left:20px;
-    width: auto;
-    height:auto;
-     white-space: pre;
-}
 
 .bonus{
   color:green;

--- a/css/style.css
+++ b/css/style.css
@@ -120,7 +120,7 @@ font-size:10px;
   margin-top:15px;
 }
 
-.trade{
+.trade, .trademax{
     border:1px solid black;
     cursor:pointer;
     padding:5px;

--- a/index.html
+++ b/index.html
@@ -342,10 +342,10 @@
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
-	<div class="trade trade_wood"></div><div class="trademax trademax_wood">Buy Max</div><br>
-	<div class="trade trade_mineral"></div><div class="trademax trademax_mineral">Buy Max</div><br>
-	<div class="trade trade_food"></div><div class="trademax trademax_food">Buy Max</div><br>
-	<div class="trade trade_sand"></div><div class="trademax trademax_sand">Buy Max</div><br><br><br>
+	<div class="trade trade_wood"></div><div class="block trademax_wood">Buy Max</div><br>
+	<div class="trade trade_mineral"></div><div class="block trademax_mineral">Buy Max</div><br>
+	<div class="trade trade_food"></div><div class="block trademax_food">Buy Max</div><br>
+	<div class="trade trade_sand"></div><div class="block trademax_sand">Buy Max</div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">

--- a/index.html
+++ b/index.html
@@ -342,10 +342,10 @@
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
-	<div class="trade trade_wood"></div><div class="trade trade_wood max"></div><br>
-	<div class="trade trade_mineral"><div class="trade trade_mineral max"></div></div><br>
-	<div class="trade trade_food"></div><div class="trade trade_food max"></div><br>
-	<div class="trade trade_sand"></div><div class="trade trade_sand max"></div><br><br><br>
+	<div class="trade trade_wood"></div><div class="trade trade_wood_max"></div><br>
+	<div class="trade trade_mineral"><div class="trade trade_mineral_max"></div></div><br>
+	<div class="trade trade_food"></div><div class="trade trade_food_max"></div><br>
+	<div class="trade trade_sand"></div><div class="trade trade_sand_max"></div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">
@@ -1063,6 +1063,7 @@
 	$(".block, .fire, .population,.toggle ,.titles,.craftamount,.encounter,.casinogame2,.ships,.tradesea,.expansionsea,.territory,.deals,.trains,.tradetrain,.currentrush,.slotmachine").hide()
 	$(".playx10,.playx100").hide()
 	$(".trade_sand").hide()
+	$(".trade_sand_max").hide()
 	$(".build_lumbermill").click(function() {build("lumbermill")});
 	$(".build_lumbermill").show()
 	$(".build_pasture").click(function() {build("pasture")});

--- a/index.html
+++ b/index.html
@@ -342,10 +342,10 @@
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
-	<div class="trade trade_wood"></div><div class="trade trade_wood_max"></div><br>
-	<div class="trade trade_mineral"><div class="trade trade_mineral_max"></div></div><br>
-	<div class="trade trade_food"></div><div class="trade trade_food_max"></div><br>
-	<div class="trade trade_sand"></div><div class="trade trade_sand_max"></div><br><br><br>
+	<div class="trade trade_wood"></div><div class="trade trade_wood_max">Max</div><br>
+	<div class="trade trade_mineral"><div class="trade trade_mineral_max">Max</div></div><br>
+	<div class="trade trade_food"></div><div class="trade trade_food_max">Max</div><br>
+	<div class="trade trade_sand"></div><div class="trade trade_sand_max">Max</div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">

--- a/index.html
+++ b/index.html
@@ -342,10 +342,10 @@
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
-	<div class="trade trade_wood"></div><div class="trade trade_wood_max">Max</div><br>
-	<div class="trade trade_mineral"></div><div class="trade trade_mineral_max">Max</div><br>
-	<div class="trade trade_food"></div><div class="trade trade_food_max">Max</div><br>
-	<div class="trade trade_sand"></div><div class="trade trade_sand_max">Max</div><br><br><br>
+	<div class="trade trade_wood"></div><div class="trademax trademax_wood">Max</div><br>
+	<div class="trade trade_mineral"></div><div class="trademax trademax_mineral">Max</div><br>
+	<div class="trade trade_food"></div><div class="trademax trademax_food">Max</div><br>
+	<div class="trade trade_sand"></div><div class="trademax trademax_sand">Max</div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">
@@ -1062,8 +1062,7 @@
 	$("#militarypane, #jobspane, #craftingpane, #technologiespane, #casinopane, #dockpane, #marketpane, #leaderpane, #legacypane, #facilitiespane").addClass("invisible");
 	$(".block, .fire, .population,.toggle ,.titles,.craftamount,.encounter,.casinogame2,.ships,.tradesea,.expansionsea,.territory,.deals,.trains,.tradetrain,.currentrush,.slotmachine").hide()
 	$(".playx10,.playx100").hide()
-	$(".trade_sand").hide()
-	$(".trade_sand_max").hide()
+	$(".trade_sand, .trademax_sand").hide()
 	$(".build_lumbermill").click(function() {build("lumbermill")});
 	$(".build_lumbermill").show()
 	$(".build_pasture").click(function() {build("pasture")});
@@ -1264,13 +1263,13 @@
 	$(".expedition").click(function() {expedition()});
         
     $(".trade_wood").click(function() {trade("wood")});
-    $(".trade_wood_max").click(function() {tradeMaximum("wood")});
+    $(".trademax_wood").click(function() {tradeMaximum("wood")});
     $(".trade_mineral").click(function() {trade("mineral")});
-    $(".trade_mineral_max").click(function() {tradeMaximum("mineral")});
+    $(".trademax_mineral").click(function() {tradeMaximum("mineral")});
     $(".trade_food").click(function() {trade("food")});
-    $(".trade_food_max").click(function() {tradeMaximum("food")});
+    $(".trademax_food").click(function() {tradeMaximum("food")});
     $(".trade_sand").click(function() {trade("sand")});
-    $(".trade_sand_max").click(function() {tradeMaximum("sand")});
+    $(".trademax_sand").click(function() {tradeMaximum("sand")});
 
     $(".leader_sucellus").click(function() {lead("sucellus")});
     $(".leader_eredal").click(function() {lead("eredal")});

--- a/index.html
+++ b/index.html
@@ -1264,13 +1264,13 @@
 	$(".expedition").click(function() {expedition()});
         
     $(".trade_wood").click(function() {trade("wood")});
-    $(".trade_wood.max").click(function() {tradeMaximum("wood")});
+    $(".trade_wood_max").click(function() {tradeMaximum("wood")});
     $(".trade_mineral").click(function() {trade("mineral")});
-    $(".trade_mineral.max").click(function() {tradeMaximum("mineral")});
+    $(".trade_mineral_max").click(function() {tradeMaximum("mineral")});
     $(".trade_food").click(function() {trade("food")});
-    $(".trade_food.max").click(function() {tradeMaximum("food")});
+    $(".trade_food_max").click(function() {tradeMaximum("food")});
     $(".trade_sand").click(function() {trade("sand")});
-    $(".trade_sand.max").click(function() {tradeMaximum("sand")});
+    $(".trade_sand_max").click(function() {tradeMaximum("sand")});
 
     $(".leader_sucellus").click(function() {lead("sucellus")});
     $(".leader_eredal").click(function() {lead("eredal")});

--- a/index.html
+++ b/index.html
@@ -1263,9 +1263,13 @@
 	$(".expedition").click(function() {expedition()});
         
     $(".trade_wood").click(function() {trade("wood")});
+    $(".trade_wood.max").click(function() {tradeMaximum("wood")});
     $(".trade_mineral").click(function() {trade("mineral")});
+    $(".trade_mineral.max").click(function() {tradeMaximum("mineral")});
     $(".trade_food").click(function() {trade("food")});
+    $(".trade_food.max").click(function() {tradeMaximum("food")});
     $(".trade_sand").click(function() {trade("sand")});
+    $(".trade_sand.max").click(function() {tradeMaximum("sand")});
 
     $(".leader_sucellus").click(function() {lead("sucellus")});
     $(".leader_eredal").click(function() {lead("eredal")});

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
 	<div class="trade trade_wood"></div><div class="trade trade_wood_max">Max</div><br>
-	<div class="trade trade_mineral"><div class="trade trade_mineral_max">Max</div></div><br>
+	<div class="trade trade_mineral"></div><div class="trade trade_mineral_max">Max</div><br>
 	<div class="trade trade_food"></div><div class="trade trade_food_max">Max</div><br>
 	<div class="trade trade_sand"></div><div class="trade trade_sand_max">Max</div><br><br><br>
 	<div class="deals">

--- a/index.html
+++ b/index.html
@@ -341,11 +341,11 @@
 	<div style="text-align:center">Resource to get</div><be>
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
-	All trades cost 1 coin: <br><br>
-	<div class="trade trade_wood"></div><br>
-	<div class="trade trade_mineral"></div><br>
-	<div class="trade trade_food"></div><br>
-	<div class="trade trade_sand"></div><br><br><br>
+	Coins can be traded for commodities at the listed per coin rate : <br><br>
+	<div class="trade trade_wood"></div><div class="trade trade_wood max"></div><br>
+	<div class="trade trade_mineral"><div class="trade trade_mineral max"></div></div><br>
+	<div class="trade trade_food"></div><div class="trade trade_food max"></div><br>
+	<div class="trade trade_sand"></div><div class="trade trade_sand max"></div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">

--- a/index.html
+++ b/index.html
@@ -342,10 +342,10 @@
 	<select class="tradetrainselect"></select><br><br><div class="tradetrainlog"></div>
 	</div>
 	Coins can be traded for commodities at the listed per coin rate : <br><br>
-	<div class="trade trade_wood"></div><div class="trademax trademax_wood">Max</div><br>
-	<div class="trade trade_mineral"></div><div class="trademax trademax_mineral">Max</div><br>
-	<div class="trade trade_food"></div><div class="trademax trademax_food">Max</div><br>
-	<div class="trade trade_sand"></div><div class="trademax trademax_sand">Max</div><br><br><br>
+	<div class="trade trade_wood"></div><div class="trademax trademax_wood">Buy Max</div><br>
+	<div class="trade trade_mineral"></div><div class="trademax trademax_mineral">Buy Max</div><br>
+	<div class="trade trade_food"></div><div class="trademax trademax_food">Buy Max</div><br>
+	<div class="trade trade_sand"></div><div class="trademax trademax_sand">Buy Max</div><br><br><br>
 	<div class="deals">
 	<div class="deallog">
 	</div><br><div class="dealtime">

--- a/js/main.js
+++ b/js/main.js
@@ -8499,10 +8499,14 @@ if(healing>0){
 $(".expedition").attr('tooltip7', "Total Healing: "+Math.round(healing));
 
 }
-tradewood=600*(bonus["trade"]+1)
-trademineral=500*(bonus["trade"]+1)
-tradefood=400*(bonus["trade"]+1)
-tradesand=20*(bonus["trade"]+1)
+tradewood=600*(bonus["trade"]+1);
+maxWoodCoin = Math.min(Math.ceil((maximums["wood"] - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+trademineral=500*(bonus["trade"]+1);
+maxMineralCoin = Math.min(Math.ceil((maximums["mineral"] - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+tradefood=400*(bonus["trade"]+1);
+maxFoodCoin = Math.min(Math.ceil((maximums["food"] - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+tradesand=20*(bonus["trade"]+1);
+maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
 	$(".trade_mineral").addClass("unavailable")
@@ -8518,10 +8522,24 @@ else
 	$(".trade_sand").removeClass("unavailable")
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
+$(".trade_wood.max").html("Max");
+$(".trade_wood.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
+$(".trade_wood.max").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
+
 $(".trade_mineral").html("Mineral: " + Math.round(trademineral));
+$(".trade_mineral.max").html("Max");
+$(".trade_mineral.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
+$(".trade_mineral.max").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
+
 $(".trade_food").html("Food: " + Math.round(tradefood));
+$(".trade_food.max").html("Max");
+$(".trade_food.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
+$(".trade_food.max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
+
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
-}
+$(".trade_sand.max").html("Max");
+$(".trade_sand.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
+$(".trade_sand.max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
 
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -8544,7 +8544,7 @@ $(".trade_food_max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tr
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
 $(".trade_sand_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
 $(".trade_sand_max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
-
+}
 
 
 function refresh(){

--- a/js/main.js
+++ b/js/main.js
@@ -8502,7 +8502,7 @@ $(".expedition").attr('tooltip7', "Total Healing: "+Math.round(healing));
 tradewood=600*(bonus["trade"]+1);
 maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 trademineral=500*(bonus["trade"]+1);
-maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
 tradefood=400*(bonus["trade"]+1);
 maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 tradesand=20*(bonus["trade"]+1);

--- a/js/main.js
+++ b/js/main.js
@@ -8500,12 +8500,13 @@ $(".expedition").attr('tooltip7', "Total Healing: "+Math.round(healing));
 
 }
 tradewood=600*(bonus["trade"]+1);
-maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 trademineral=500*(bonus["trade"]+1);
-maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
 tradefood=400*(bonus["trade"]+1);
-maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 tradesand=20*(bonus["trade"]+1);
+
+maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
@@ -8974,13 +8975,15 @@ function trade(b){
 function tradeMaximum(b){
 	if (craft["coin"]>=1){
 		tradewood=600*(bonus["trade"]+1);
-		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 		trademineral=500*(bonus["trade"]+1);
-		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
 		tradefood=400*(bonus["trade"]+1);
-		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 		tradesand=20*(bonus["trade"]+1);
+		
+		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 		maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+		
 		if(b=="wood") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 		else if(b=="food") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }

--- a/js/main.js
+++ b/js/main.js
@@ -8500,13 +8500,13 @@ $(".expedition").attr('tooltip7', "Total Healing: "+Math.round(healing));
 
 }
 tradewood=600*(bonus["trade"]+1);
-maxWoodCoin = Math.min(Math.ceil((maximums["wood"] - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 trademineral=500*(bonus["trade"]+1);
-maxMineralCoin = Math.min(Math.ceil((maximums["mineral"] - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
 tradefood=400*(bonus["trade"]+1);
-maxFoodCoin = Math.min(Math.ceil((maximums["food"] - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 tradesand=20*(bonus["trade"]+1);
-maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
 	$(".trade_wood_max").addClass("unavailable")
@@ -8974,13 +8974,13 @@ function trade(b){
 function tradeMaximum(b){
 	if (craft["coin"]>=1){
 		tradewood=600*(bonus["trade"]+1);
-		maxWoodCoin = Math.min(Math.ceil((maximums["wood"] - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 		trademineral=500*(bonus["trade"]+1);
-		maxMineralCoin = Math.min(Math.ceil((maximums["mineral"] - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
 		tradefood=400*(bonus["trade"]+1);
-		maxFoodCoin = Math.min(Math.ceil((maximums["food"] - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 		tradesand=20*(bonus["trade"]+1);
-		maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+		maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 		if(b=="wood") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 		else if(b=="food") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }

--- a/js/main.js
+++ b/js/main.js
@@ -8504,10 +8504,10 @@ trademineral=500*(bonus["trade"]+1);
 tradefood=400*(bonus["trade"]+1);
 tradesand=20*(bonus["trade"]+1);
 
-maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
-maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
-maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
-maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+var maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+var maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+var maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+var maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
@@ -8980,15 +8980,15 @@ function tradeMaximum(b){
 		tradefood=400*(bonus["trade"]+1);
 		tradesand=20*(bonus["trade"]+1);
 		
-		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
-		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
-		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
-		maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+		var maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+		var maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+		var maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+		var maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 		
 		if(b=="wood") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="food") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="sand") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxMineralCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="food") { for(var MaxTradeCt = 0; MaxTradeCt < maxFoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="sand") { for(var MaxTradeCt = 0; MaxTradeCt < maxSandCoin; MaxTradeCt++) { trade(b); } }
 	}
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -2899,7 +2899,7 @@ function research(b){
 
 			technologies["commodities"]++
 			$(".trade_sand").show()
-			$(".trade_sand_max").show()
+			$(".trademax_sand").show()
 			unlocked[".trade_sand"]=1;
 
 		}
@@ -8512,41 +8512,41 @@ var maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - 
 
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
-	$(".trade_wood_max").addClass("unavailable")
+	$(".trademax_wood").addClass("unavailable")
 	$(".trade_mineral").addClass("unavailable")
-	$(".trade_mineral_max").addClass("unavailable")
+	$(".trademax_mineral").addClass("unavailable")
 	$(".trade_food").addClass("unavailable")
-	$(".trade_food_max").addClass("unavailable")
+	$(".trademax_food").addClass("unavailable")
 	$(".trade_sand").addClass("unavailable")
-	$(".trade_sand_max").addClass("unavailable")
+	$(".trademax_sand").addClass("unavailable")
 }
 else
 {
 
 	$(".trade_wood").removeClass("unavailable")
-	$(".trade_wood_max").removeClass("unavailable")
+	$(".trademax_wood").removeClass("unavailable")
 	$(".trade_mineral").removeClass("unavailable")
-	$(".trade_mineral_max").removeClass("unavailable")
+	$(".trademax_mineral").removeClass("unavailable")
 	$(".trade_food").removeClass("unavailable")
-	$(".trade_food_max").removeClass("unavailable")
+	$(".trademax_food").removeClass("unavailable")
 	$(".trade_sand").removeClass("unavailable")
-	$(".trade_sand_max").removeClass("unavailable")
+	$(".trademax_sand").removeClass("unavailable")
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
-$(".trade_wood_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
-$(".trade_wood_max").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
+$(".trademax_wood").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
+$(".trademax_wood").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
 
 $(".trade_mineral").html("Mineral: " + Math.round(trademineral));
-$(".trade_mineral_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
-$(".trade_mineral_max").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
+$(".trademax_mineral").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
+$(".trademax_mineral").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
 
 $(".trade_food").html("Food: " + Math.round(tradefood));
-$(".trade_food_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
-$(".trade_food_max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
+$(".trademax_food").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
+$(".trademax_food").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
 
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
-$(".trade_sand_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
-$(".trade_sand_max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
+$(".trademax_sand").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
+$(".trademax_sand").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -8980,10 +8980,10 @@ function tradeMaximum(b){
 		tradefood=400*(bonus["trade"]+1);
 		tradesand=20*(bonus["trade"]+1);
 		
-		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
-		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
-		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
-		maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+		maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+		maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+		maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+		maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 		
 		if(b=="wood") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }

--- a/js/main.js
+++ b/js/main.js
@@ -8942,9 +8942,8 @@ calculatecost();
 autorefresh();
 
 }
+
 function trade(b){
-
-
 	if (craft["coin"]>=1){
 		tradewood=600*(bonus["trade"]+1)
 		trademineral=500*(bonus["trade"]+1)
@@ -8966,14 +8965,23 @@ function trade(b){
 			items["sand"]+=Math.round(tradesand)
 			craft["coin"]-=1
 		}
-
 	}
-
-
-
-
-
-
+}
+function tradeMaximum(b){
+	if (craft["coin"]>=1){
+		tradewood=600*(bonus["trade"]+1);
+		maxWoodCoin = Math.min(Math.ceil((maximums["wood"] - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
+		trademineral=500*(bonus["trade"]+1);
+		maxMineralCoin = Math.min(Math.ceil((maximums["mineral"] - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
+		tradefood=400*(bonus["trade"]+1);
+		maxFoodCoin = Math.min(Math.ceil((maximums["food"] - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+		tradesand=20*(bonus["trade"]+1);
+		maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+		if(b=="wood")			{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="mineral")	{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="food")		{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="sand")		{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+	}
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -8527,25 +8527,29 @@ var maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - 
 var maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 
 if(craft["coin"]<1){
-	$(".trade_wood").addClass("unavailable")
-	$(".trademax_wood").addClass("unavailable")
-	$(".trade_mineral").addClass("unavailable")
-	$(".trademax_mineral").addClass("unavailable")
-	$(".trade_food").addClass("unavailable")
-	$(".trademax_food").addClass("unavailable")
-	$(".trade_sand").addClass("unavailable")
-	$(".trademax_sand").addClass("unavailable")
+	$(".trade_wood").addClass("unavailable");
+	$(".trademax_wood").addClass("unavailable");
+	$(".trade_mineral").addClass("unavailable");
+	$(".trademax_mineral").addClass("unavailable");
+	$(".trade_food").addClass("unavailable");
+	$(".trademax_food").addClass("unavailable");
+	$(".trade_sand").addClass("unavailable");
+	$(".trademax_sand").addClass("unavailable");
 }
 else
 {
-	$(".trade_wood").removeClass("unavailable")
-	$(".trademax_wood").removeClass("unavailable")
-	$(".trade_mineral").removeClass("unavailable")
-	$(".trademax_mineral").removeClass("unavailable")
-	$(".trade_food").removeClass("unavailable")
-	$(".trademax_food").removeClass("unavailable")
-	$(".trade_sand").removeClass("unavailable")
-	$(".trademax_sand").removeClass("unavailable")
+	$(".trade_wood").removeClass("unavailable");
+	$(".trademax_wood").removeClass("unavailable");
+	$(".trademax_wood").show();
+	$(".trade_mineral").removeClass("unavailable");
+	$(".trademax_mineral").removeClass("unavailable");
+	$(".trademax_mineral").show();
+	$(".trade_food").removeClass("unavailable");
+	$(".trademax_food").removeClass("unavailable");
+	$(".trademax_food").show();
+	$(".trade_sand").removeClass("unavailable");
+	$(".trademax_sand").removeClass("unavailable");
+	$(".trademax_sand").show();
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
 $(".trademax_wood").attr('tooltip', 'Coin Cost:');

--- a/js/main.js
+++ b/js/main.js
@@ -2917,6 +2917,7 @@ function research(b){
 			$(".trade_sand").show()
 			$(".trademax_sand").show()
 			unlocked[".trade_sand"]=1;
+			
 
 		}
 
@@ -8528,28 +8529,24 @@ var maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - 
 
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable");
-	$(".trademax_wood").addClass("unavailable");
+	$(".trademax_wood").hide();
 	$(".trade_mineral").addClass("unavailable");
-	$(".trademax_mineral").addClass("unavailable");
+	$(".trademax_mineral").hide();
 	$(".trade_food").addClass("unavailable");
-	$(".trademax_food").addClass("unavailable");
+	$(".trademax_food").hide();
 	$(".trade_sand").addClass("unavailable");
-	$(".trademax_sand").addClass("unavailable");
+	$(".trademax_sand").hide();
 }
 else
 {
 	$(".trade_wood").removeClass("unavailable");
-	$(".trademax_wood").removeClass("unavailable");
 	$(".trademax_wood").show();
 	$(".trade_mineral").removeClass("unavailable");
-	$(".trademax_mineral").removeClass("unavailable");
 	$(".trademax_mineral").show();
 	$(".trade_food").removeClass("unavailable");
-	$(".trademax_food").removeClass("unavailable");
 	$(".trademax_food").show();
 	$(".trade_sand").removeClass("unavailable");
-	$(".trademax_sand").removeClass("unavailable");
-	$(".trademax_sand").show();
+	if ( technologies["commodities"] != 0 ) { $(".trademax_sand").show(); }
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
 $(".trademax_wood").attr('tooltip', 'Coin Cost:');

--- a/js/main.js
+++ b/js/main.js
@@ -2899,6 +2899,7 @@ function research(b){
 
 			technologies["commodities"]++
 			$(".trade_sand").show()
+			$(".trade_sand_max").show()
 			unlocked[".trade_sand"]=1;
 
 		}

--- a/js/main.js
+++ b/js/main.js
@@ -8540,13 +8540,13 @@ if(craft["coin"]<1){
 else
 {
 	$(".trade_wood").removeClass("unavailable");
-	if ( maxWoodCoin > 0 ) { $(".trademax_wood").show(); }
+	$(".trademax_wood").show(); 
 	$(".trade_mineral").removeClass("unavailable");
-	if ( maxMineralCoin > 0 ) { $(".trademax_mineral").show(); }
+	$(".trademax_mineral").show();
 	$(".trade_food").removeClass("unavailable");
-	if ( maxFoodCoin > 0 ) { $(".trademax_food").show(); }
+	$(".trademax_food").show();
 	$(".trade_sand").removeClass("unavailable");
-	if (  maxSandCoin > 0 && technologies["commodities"] != 0 ) { $(".trademax_sand").show(); }
+	if ( technologies["commodities"] != 0 ) { $(".trademax_sand").show(); }
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
 $(".trademax_wood").attr('tooltip', 'Coin Cost:');

--- a/js/main.js
+++ b/js/main.js
@@ -8506,8 +8506,9 @@ tradesand=20*(bonus["trade"]+1);
 
 maxWoodCoin = Math.min(Math.ceil(((maximums["wood"]*(bonus["storage"]+1)) - items["wood"]) / Math.round(tradewood)), Math.floor(craft["coin"]));
 maxMineralCoin = Math.min(Math.ceil(((maximums["mineral"]*(bonus["storage"]+1)) - items["mineral"]) / Math.round(trademineral)), Math.floor(craft["coin"]));
-maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
-maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+maxFoodCoin = Math.min(Math.ceil(((maximums["food"]*(bonus["storage"]+1)) - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
+maxSandCoin = Math.min(Math.ceil(((maximums["sand"]*(bonus["storage"]+1)) - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
+
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
 	$(".trade_wood_max").addClass("unavailable")

--- a/js/main.js
+++ b/js/main.js
@@ -8530,22 +8530,18 @@ else
 	$(".trade_sand_max").removeClass("unavailable")
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
-$(".trade_wood_max").html("Max");
 $(".trade_wood_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
 $(".trade_wood_max").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
 
 $(".trade_mineral").html("Mineral: " + Math.round(trademineral));
-$(".trade_mineral_max").html("Max");
 $(".trade_mineral_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
 $(".trade_mineral_max").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
 
 $(".trade_food").html("Food: " + Math.round(tradefood));
-$(".trade_food_max").html("Max");
 $(".trade_food_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
 $(".trade_food_max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
 
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
-$(".trade_sand_max").html("Max");
 $(".trade_sand_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
 $(".trade_sand_max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
 

--- a/js/main.js
+++ b/js/main.js
@@ -8509,37 +8509,45 @@ tradesand=20*(bonus["trade"]+1);
 maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
 if(craft["coin"]<1){
 	$(".trade_wood").addClass("unavailable")
+	$(".trade_wood_max").addClass("unavailable")
 	$(".trade_mineral").addClass("unavailable")
+	$(".trade_mineral_max").addClass("unavailable")
 	$(".trade_food").addClass("unavailable")
+	$(".trade_food_max").addClass("unavailable")
 	$(".trade_sand").addClass("unavailable")
+	$(".trade_sand_max").addClass("unavailable")
 }
 else
 {
 
 	$(".trade_wood").removeClass("unavailable")
+	$(".trade_wood_max").removeClass("unavailable")
 	$(".trade_mineral").removeClass("unavailable")
+	$(".trade_mineral_max").removeClass("unavailable")
 	$(".trade_food").removeClass("unavailable")
+	$(".trade_food_max").removeClass("unavailable")
 	$(".trade_sand").removeClass("unavailable")
+	$(".trade_sand_max").removeClass("unavailable")
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
-$(".trade_wood.max").html("Max");
-$(".trade_wood.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
-$(".trade_wood.max").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
+$(".trade_wood_max").html("Max");
+$(".trade_wood_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
+$(".trade_wood_max").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
 
 $(".trade_mineral").html("Mineral: " + Math.round(trademineral));
-$(".trade_mineral.max").html("Max");
-$(".trade_mineral.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
-$(".trade_mineral.max").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
+$(".trade_mineral_max").html("Max");
+$(".trade_mineral_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
+$(".trade_mineral_max").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
 
 $(".trade_food").html("Food: " + Math.round(tradefood));
-$(".trade_food.max").html("Max");
-$(".trade_food.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
-$(".trade_food.max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
+$(".trade_food_max").html("Max");
+$(".trade_food_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
+$(".trade_food_max").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
 
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
-$(".trade_sand.max").html("Max");
-$(".trade_sand.max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
-$(".trade_sand.max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
+$(".trade_sand_max").html("Max");
+$(".trade_sand_max").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
+$(".trade_sand_max").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
 
 
 
@@ -8977,10 +8985,10 @@ function tradeMaximum(b){
 		maxFoodCoin = Math.min(Math.ceil((maximums["food"] - items["food"]) / Math.round(tradefood)), Math.floor(craft["coin"]));
 		tradesand=20*(bonus["trade"]+1);
 		maxSandCoin = Math.min(Math.ceil((maximums["sand"] - items["sand"]) / Math.round(tradesand)), Math.floor(craft["coin"]));
-		if(b=="wood")			{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="mineral")	{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="food")		{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
-		else if(b=="sand")		{ for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		if(b=="wood") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="mineral") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="food") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
+		else if(b=="sand") { for(var MaxTradeCt = 0; MaxTradeCt < maxWoodCoin; MaxTradeCt++) { trade(b); } }
 	}
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -8522,7 +8522,6 @@ if(craft["coin"]<1){
 }
 else
 {
-
 	$(".trade_wood").removeClass("unavailable")
 	$(".trademax_wood").removeClass("unavailable")
 	$(".trade_mineral").removeClass("unavailable")
@@ -8533,20 +8532,28 @@ else
 	$(".trademax_sand").removeClass("unavailable")
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
-$(".trademax_wood").attr('tooltip', 'Spend Coins: ' + parseFloat(maxWoodCoin).toFixed(0));
-$(".trademax_wood").attr('tooltip2', 'For Wood: ' + parseFloat(maxWoodCoin * tradewood).toFixed(0));
+$(".trademax_wood").attr('tooltip', 'Coin Cost:');
+$(".trademax_wood").attr('tooltip2', parseFloat(maxWoodCoin).toFixed(0));
+$(".trademax_wood").attr('tooltip4', 'Wood Purchased:');
+$(".trademax_wood").attr('tooltip5', parseFloat(maxWoodCoin * tradewood).toFixed(0));
 
 $(".trade_mineral").html("Mineral: " + Math.round(trademineral));
-$(".trademax_mineral").attr('tooltip', 'Spend Coins: ' + parseFloat(maxMineralCoin).toFixed(0));
-$(".trademax_mineral").attr('tooltip2', 'For Mineral: ' + parseFloat(maxMineralCoin * trademineral).toFixed(0));
+$(".trademax_mineral").attr('tooltip', 'Coin Cost:');
+$(".trademax_mineral").attr('tooltip2', parseFloat(maxMineralCoin).toFixed(0));
+$(".trademax_mineral").attr('tooltip4', 'Minerals Purchased:');
+$(".trademax_mineral").attr('tooltip5', parseFloat(maxMineralCoin * trademineral).toFixed(0));
 
 $(".trade_food").html("Food: " + Math.round(tradefood));
-$(".trademax_food").attr('tooltip', 'Spend Coins: ' + parseFloat(maxFoodCoin).toFixed(0));
-$(".trademax_food").attr('tooltip2', 'For Food: ' + parseFloat(maxFoodCoin * tradefood).toFixed(0));
+$(".trademax_food").attr('tooltip', 'Coin Cost:');
+$(".trademax_food").attr('tooltip2', parseFloat(maxFoodCoin).toFixed(0));
+$(".trademax_food").attr('tooltip4', 'Food Purchased:');
+$(".trademax_food").attr('tooltip5', parseFloat(maxFoodCoin * tradefood).toFixed(0));
 
 $(".trade_sand").html("Sand: " + Math.round(tradesand));
-$(".trademax_sand").attr('tooltip', 'Spend Coins: ' + parseFloat(maxSandCoin).toFixed(0));
-$(".trademax_sand").attr('tooltip2', 'For Sand: ' + parseFloat(maxSandCoin * tradesand).toFixed(0));
+$(".trademax_sand").attr('tooltip', 'Coin Cost:');
+$(".trademax_sand").attr('tooltip2', parseFloat(maxSandCoin).toFixed(0));
+$(".trademax_sand").attr('tooltip4', 'Sand Purchased:');
+$(".trademax_sand").attr('tooltip5', parseFloat(maxSandCoin * tradesand).toFixed(0));
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -8540,13 +8540,13 @@ if(craft["coin"]<1){
 else
 {
 	$(".trade_wood").removeClass("unavailable");
-	$(".trademax_wood").show();
+	if ( maxWoodCoin > 0 ) { $(".trademax_wood").show(); }
 	$(".trade_mineral").removeClass("unavailable");
-	$(".trademax_mineral").show();
+	if ( maxMineralCoin > 0 ) { $(".trademax_mineral").show(); }
 	$(".trade_food").removeClass("unavailable");
-	$(".trademax_food").show();
+	if ( maxFoodCoin > 0 ) { $(".trademax_food").show(); }
 	$(".trade_sand").removeClass("unavailable");
-	if ( technologies["commodities"] != 0 ) { $(".trademax_sand").show(); }
+	if (  maxSandCoin > 0 && technologies["commodities"] != 0 ) { $(".trademax_sand").show(); }
 }
 $(".trade_wood").html("Wood: " + Math.round(tradewood));
 $(".trademax_wood").attr('tooltip', 'Coin Cost:');


### PR DESCRIPTION
This pull request adds a 'buy max' button for all players with access to the marketplace. This should reduce the tedium of the marketplace pane/tab, and make it easier for players to spend their earned coins.

It does so by adding 4 buttons of the CSS class .block.trademax_COMMODITY to the marketplace pane (where COMMODITY is wood/mineral/food/sand. The buttons are revealed only when the player has at least one coin and the marketplace pane available. The sand buymax is revealed when the player has the tech-commodity researched.

While the functionality of the javascript works as intended, I'm not terribly pleased with the way the CSS causes the buttons to look. Unfortunately, I know very little about CSS and wasn't able to get anything to work. I look forward to seeing how it can be improved.

Cheers,

-Rot
