### PR TITLE
make auto bonus depend on craft ratio

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5084,7 +5084,7 @@ if(buildstatus["workshop"]==1 && items["coal"]>=buildings["workshop"]*0.0075 && 
 {
 	consumption["coal"]+=buildings["workshop"]*0.0075
 	consumption["chemicals"]+=buildings["workshop"]*0.0025
-	bonus["auto"]=buildings["workshop"]*0.10
+	bonus["auto"] = buildings["workshop"] * 0.10 * bonus['craft']
 }
 else
 {


### PR DESCRIPTION
I feel the auto bonus is too insignificant it would be more exciting if took a fraction of the craft ratio instead. Since in end game you will want to automate more things than manual crafting it preserves the incentive to increase craft ratio and makes the auto bonus more significant.
